### PR TITLE
feat: Implement CNPJ lookup for Enterprise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Run Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configuring environment
+        uses: actions/setup-go@v4
+        with:
+          go-version: ^1.24.1
+
+      - name: Cloning repository
+        uses: actions/checkout@v4
+
+      - name: Run all enterprise tests
+        run: go test ./... --race -cover

--- a/cnpj.go
+++ b/cnpj.go
@@ -1,0 +1,68 @@
+package enterprise
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/i9si-sistemas/cep/api"
+	"github.com/i9si-sistemas/nine"
+	"github.com/i9si-sistemas/nine/pkg/client"
+)
+
+func WithCNPJ(ctx context.Context, cnpj string) (Enterprise, error) {
+	url := fmt.Sprintf("https://www.receitaws.com.br/v1/cnpj/%s", cleanCNPJ(cnpj))
+	res, err := nine.New(ctx).Get(url, &client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("erro ao fazer a requisição: %v", err)
+	}
+	enterprise := enterpriseWithCNPJ{
+		ctx:    ctx,
+		reader: res.Body,
+		cnpj:   cnpj,
+	}
+	var payload nine.JSON
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("erro ao decodificar a resposta: %v", err)
+	}
+	enterprise.json = payload
+	return &enterprise, nil
+}
+
+func cleanCEP(cep string) string {
+	return strings.NewReplacer(".", "", "-", "", "/", "").Replace(cep)
+}
+
+func cleanCNPJ(cnpj string) string {
+	return strings.NewReplacer(".", "", "-", "", "/", "").Replace(cnpj)
+}
+
+type enterpriseWithCNPJ struct {
+	ctx    context.Context
+	cnpj   string
+	json   nine.JSON
+	reader io.Reader
+}
+
+func (e *enterpriseWithCNPJ) Data() nine.JSON {
+	return e.json
+}
+
+func (e *enterpriseWithCNPJ) CEP() *api.CEP {
+	data := e.Data()
+	cep, err := api.Find(e.ctx, cleanCEP(data["cep"].(string)))
+	if err != nil {
+		return nil
+	}
+	return cep
+}
+
+func (e *enterpriseWithCNPJ) Reader() io.Reader {
+	return e.reader
+}
+
+func (e *enterpriseWithCNPJ) String() string {
+	return fmt.Sprintf("CNPJ: %s", e.cnpj)
+}

--- a/cnpj_test.go
+++ b/cnpj_test.go
@@ -1,0 +1,28 @@
+package enterprise
+
+import (
+	"context"
+	"testing"
+
+	"github.com/i9si-sistemas/assert"
+)
+
+func TestWithCNPJ(t *testing.T) {
+	cnpj := "00.000.000/0001-91"
+	ctx := context.Background()
+	enterprise, err := WithCNPJ(ctx, cnpj)
+	if err != nil {
+		t.Skipf("Erro ao consultar a empresa através do CNPJ: %s", err.Error())
+	}
+	assert.NotNil(t, enterprise)
+	data := enterprise.Data()
+	assert.NotNil(t, data)
+	assert.Equal(t, data["cnpj"].(string), cnpj)
+	assert.Equal(t, data["nome"].(string), "BANCO DO BRASIL SA")
+	assert.Equal(t, data["cep"].(string), "70.040-912")
+	cep := enterprise.CEP()
+	if cep == nil {
+		t.Skip("Erro ao consultar o CEP")
+	}
+	assert.Equal(t, cep.ZipCode, "70040-912")
+}

--- a/enterprise.go
+++ b/enterprise.go
@@ -1,0 +1,14 @@
+package enterprise
+
+import (
+	"io"
+
+	"github.com/i9si-sistemas/cep/api"
+	"github.com/i9si-sistemas/nine"
+)
+
+type Enterprise interface {
+	Data() nine.JSON
+	CEP() *api.CEP
+	Reader() io.Reader
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/i9si-sistemas/enterprise
+
+go 1.24.1
+
+require (
+	github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c
+	github.com/i9si-sistemas/cep v0.0.0-20250505170137-9e3cce248a9f
+	github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c h1:8DlRk8oT2YFyo8MbY00ge2wEEGGLZWr2mGJextdSePI=
+github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c/go.mod h1:xRwY4u6NZZjNLlgdBSaNESQEUSJ4CxuT4lWQAbvwfBQ=
+github.com/i9si-sistemas/cep v0.0.0-20250505170137-9e3cce248a9f h1:QWP3oa5nsDorHFePfEgtBbUvCOO6Cy/iByIE13qzFNI=
+github.com/i9si-sistemas/cep v0.0.0-20250505170137-9e3cce248a9f/go.mod h1:2unwB504M7nk318ChQv3PDR+EWWMr90vxNmMO5BC9CQ=
+github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71 h1:yIyAEA40c0nxTVmDbU+It7IbTlf4myqfknBy8yhXqwY=
+github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71/go.mod h1:6j/47ihyu5Zz9S4RTIQ939jbbz2Zb9ZYshM7TA6LnT8=


### PR DESCRIPTION
This PR implements the `WithCNPJ` function, which allows retrieving enterprise data using a CNPJ.

The implementation:
- Defines the `enterpriseWithCNPJ` struct that implements the `Enterprise` interface.
- Uses the `receitaws.com.br` API to fetch enterprise data based on the provided CNPJ.
- Implements methods to clean CNPJ and CEP strings.
- Implements the `Data()`, `CEP()`, `Reader()`, and `String()` methods for the `enterpriseWithCNPJ` struct.