### PR TITLE
refactor: Using stringx.Replacer for cleaning CNPJ and CEP 

### DIFF
--- a/cnpj.go
+++ b/cnpj.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/i9si-sistemas/cep/api"
 	"github.com/i9si-sistemas/nine"
 	"github.com/i9si-sistemas/nine/pkg/client"
+	"github.com/i9si-sistemas/stringx"
 )
 
 func WithCNPJ(ctx context.Context, cnpj string) (Enterprise, error) {
@@ -32,11 +32,29 @@ func WithCNPJ(ctx context.Context, cnpj string) (Enterprise, error) {
 }
 
 func cleanCEP(cep string) string {
-	return strings.NewReplacer(".", "", "-", "", "/", "").Replace(cep)
+	return cleaner{s: cep}.Clean()
 }
 
 func cleanCNPJ(cnpj string) string {
-	return strings.NewReplacer(".", "", "-", "", "/", "").Replace(cnpj)
+	return cleaner{s: cnpj}.Clean()
+}
+
+type cleaner struct {
+	s string
+}
+
+func (c cleaner) Clean() string {
+	var (
+		empty = stringx.Empty.String()
+		old   = []string{".", "-", "/"}
+		new   = []string{empty, empty, empty}
+	)
+	s, _ := stringx.NewReplacer(
+		stringx.String(c.s),
+		old,
+		new,
+	).Replace()
+	return s
 }
 
 type enterpriseWithCNPJ struct {

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c
 	github.com/i9si-sistemas/cep v0.0.0-20250505170137-9e3cce248a9f
 	github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71
+	github.com/i9si-sistemas/stringx v1.5.1
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.24.1
 require (
 	github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c
 	github.com/i9si-sistemas/cep v0.0.0-20250505170137-9e3cce248a9f
-	github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71
+	github.com/i9si-sistemas/nine v1.3.1
 	github.com/i9si-sistemas/stringx v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/i9si-sistemas/cep v0.0.0-20250505170137-9e3cce248a9f h1:QWP3oa5nsDorH
 github.com/i9si-sistemas/cep v0.0.0-20250505170137-9e3cce248a9f/go.mod h1:2unwB504M7nk318ChQv3PDR+EWWMr90vxNmMO5BC9CQ=
 github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71 h1:yIyAEA40c0nxTVmDbU+It7IbTlf4myqfknBy8yhXqwY=
 github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71/go.mod h1:6j/47ihyu5Zz9S4RTIQ939jbbz2Zb9ZYshM7TA6LnT8=
+github.com/i9si-sistemas/stringx v1.5.1 h1:DtQRd2gm7Qrl7ToHR1axApfGF78Qiv5MCD63Cd6ZPjE=
+github.com/i9si-sistemas/stringx v1.5.1/go.mod h1:+GhyHUFCjPCdi4BOTLuXI1O0VE0YZP1kn32XEcb9bk4=

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/i9si-sistemas/cep v0.0.0-20250505170137-9e3cce248a9f h1:QWP3oa5nsDorH
 github.com/i9si-sistemas/cep v0.0.0-20250505170137-9e3cce248a9f/go.mod h1:2unwB504M7nk318ChQv3PDR+EWWMr90vxNmMO5BC9CQ=
 github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71 h1:yIyAEA40c0nxTVmDbU+It7IbTlf4myqfknBy8yhXqwY=
 github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71/go.mod h1:6j/47ihyu5Zz9S4RTIQ939jbbz2Zb9ZYshM7TA6LnT8=
+github.com/i9si-sistemas/nine v1.3.1 h1:lViGBqDPLczxLa7jqnGdTi6NQMFB9XKA7cQg5bgIHuc=
+github.com/i9si-sistemas/nine v1.3.1/go.mod h1:xLeJ16P6gmSpokmZ3mZq4KVJlV2DJE/aBlIZETbU140=
 github.com/i9si-sistemas/stringx v1.5.1 h1:DtQRd2gm7Qrl7ToHR1axApfGF78Qiv5MCD63Cd6ZPjE=
 github.com/i9si-sistemas/stringx v1.5.1/go.mod h1:+GhyHUFCjPCdi4BOTLuXI1O0VE0YZP1kn32XEcb9bk4=


### PR DESCRIPTION
## Changes:
- Replaces `strings.NewReplacer` with `stringx.NewReplacer` in `cleanCNPJ` and `cleanCEP` functions.
- Introduces a `cleaner` struct with a `Clean` method to encapsulate the replacement logic.
- Uses `stringx.Empty.String()` for empty string representation.